### PR TITLE
electron-storeの導入 / UI一部変更 / 詳細画面の追加

### DIFF
--- a/data/genreData.json
+++ b/data/genreData.json
@@ -1,17 +1,17 @@
 [
-  {
-    "id": 0,
-    "color": "#FFFFFF",
-    "name": "work"
-  },
-  {
-    "id": 1,
-    "color": "#FFFF00",
-    "name": "school"
-  },
-  {
-    "id": 2,
-    "color": "#00FFFF",
-    "name": "house"
-  }
+    {
+        "id": 0,
+        "color": "#d7c447",
+        "name": "work"
+    },
+    {
+        "id": 1,
+        "color": "#00ac9b",
+        "name": "school"
+    },
+    {
+        "id": 2,
+        "color": "#b6007a",
+        "name": "house"
+    }
 ]

--- a/data/todoData.json
+++ b/data/todoData.json
@@ -27,7 +27,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 0,
+        "genreId": 2,
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -84,7 +84,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 0,
+        "genreId": 1,
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -122,7 +122,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 0,
+        "genreId": 2,
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -160,7 +160,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 0,
+        "genreId": 1,
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -217,7 +217,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 0,
+        "genreId": 2,
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -255,7 +255,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 0,
+        "genreId": 2,
         "contents": "work at the office.",
         "deadline": {
             "year": 2020,
@@ -293,7 +293,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 0,
+        "genreId": 1,
         "contents": "work at the office.",
         "deadline": {
             "year": 2020,

--- a/data/todoData.json
+++ b/data/todoData.json
@@ -214,8 +214,8 @@
         "manHour": {
             "year": 0,
             "month": 0,
-            "day": 0,
-            "hour": 3
+            "day": 12,
+            "hour": 0
         },
         "genreId": 2,
         "contents": "work at the office.",
@@ -231,9 +231,9 @@
         "title": "12:A2",
         "importance": "B",
         "manHour": {
-            "year": 0,
-            "month": 0,
-            "day": 0,
+            "year": 2,
+            "month": 1,
+            "day": 10,
             "hour": 3
         },
         "genreId": 0,
@@ -271,8 +271,8 @@
         "manHour": {
             "year": 0,
             "month": 0,
-            "day": 0,
-            "hour": 3
+            "day": 1,
+            "hour": 0
         },
         "genreId": 0,
         "contents": "work at the office.",
@@ -288,7 +288,7 @@
         "title": "15:A11",
         "importance": "A",
         "manHour": {
-            "year": 0,
+            "year": 2,
             "month": 0,
             "day": 0,
             "hour": 3

--- a/package-lock.json
+++ b/package-lock.json
@@ -290,6 +290,46 @@
         }
       }
     },
+    "conf": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-6.2.0.tgz",
+      "integrity": "sha512-fvl40R6YemHrFsNiyP7TD0tzOe3pQD2dfT2s20WvCaq57A1oV+RImbhn2Y4sQGDz1lB0wNSb7dPcPIvQB69YNA==",
+      "requires": {
+        "ajv": "^6.10.2",
+        "debounce-fn": "^3.0.1",
+        "dot-prop": "^5.0.0",
+        "env-paths": "^2.2.0",
+        "json-schema-typed": "^7.0.1",
+        "make-dir": "^3.0.0",
+        "onetime": "^5.1.0",
+        "pkg-up": "^3.0.1",
+        "semver": "^6.2.0",
+        "write-file-atomic": "^3.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.10.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+          "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "env-paths": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+          "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
+      }
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -312,6 +352,14 @@
       "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "debounce-fn": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-3.0.1.tgz",
+      "integrity": "sha512-aBoJh5AhpqlRoHZjHmOzZlRx+wz2xVwGL9rjs+Kj0EWUrL4/h4K7OD176thl2Tdoqui/AaA4xhHrNArGLAaI3Q==",
+      "requires": {
+        "mimic-fn": "^2.1.0"
       }
     },
     "debug": {
@@ -346,6 +394,14 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
       "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
       "dev": true
+    },
+    "dot-prop": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+      "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+      "requires": {
+        "is-obj": "^2.0.0"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -383,6 +439,15 @@
         "rc": "^1.2.1",
         "semver": "^5.4.1",
         "sumchecker": "^2.0.2"
+      }
+    },
+    "electron-store": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-5.1.0.tgz",
+      "integrity": "sha512-uhAF/4+zDb+y0hWqlBirEPEAR4ciCZDp4fRWGFNV62bG+ArdQPpXk7jS0MEVj3CfcG5V7hx7Dpq5oD+1j6GD8Q==",
+      "requires": {
+        "conf": "^6.2.0",
+        "type-fest": "^0.7.1"
       }
     },
     "env-paths": {
@@ -462,14 +527,12 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fd-slicer": {
       "version": "1.0.1",
@@ -623,6 +686,11 @@
         "sshpk": "^1.7.0"
       }
     },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+    },
     "indent-string": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
@@ -678,11 +746,15 @@
         "number-is-nan": "^1.0.0"
       }
     },
+    "is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -733,8 +805,12 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-schema-typed": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.2.tgz",
+      "integrity": "sha512-40FRIcBSz4y0Ego3gMpbkhtIgebpxKRgW/7i1FfDNL4/xEPQKBM12tKSiCZFNQvad5K4IS3I5Sc8cxza/KSwog=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -776,6 +852,15 @@
         "strip-bom": "^2.0.0"
       }
     },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -784,6 +869,21 @@
       "requires": {
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
+      }
+    },
+    "make-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+      "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "map-obj": {
@@ -829,6 +929,11 @@
       "requires": {
         "mime-db": "1.40.0"
       }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -962,6 +1067,35 @@
         "wrappy": "1"
       }
     },
+    "onetime": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+    },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -974,8 +1108,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1033,6 +1166,24 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "requires": {
+        "find-up": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        }
+      }
+    },
     "pretty-bytes": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
@@ -1068,8 +1219,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -1199,8 +1349,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "single-line-log": {
       "version": "1.1.2",
@@ -1444,11 +1593,24 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
+    "type-fest": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "typescript": {
       "version": "3.4.5",
@@ -1466,7 +1628,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -1509,6 +1670,17 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "write-file-atomic": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
+      "integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
     },
     "xtend": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "typescript": "^3.4.1"
   },
   "dependencies": {
+    "electron-store": "^5.1.0",
     "fs": "0.0.1-security",
     "material-design-lite": "^1.3.0"
   }

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -25,11 +25,11 @@
             削除
         </button>
         <i class="far fa-star" style="visibility:hidden;"></i>
-        <input type="image" src="../img/settings.svg" alt="設定画面を開く" class="mdl-button mdl-js-button" id="setting-btn" >
-        
+        <input type="image" src="../img/settings.svg" alt="設定画面を開く" class="mdl-button mdl-js-button" id="setting-btn">
+
     </div>
 
-        <!-- All of the Node.js APIs are available in this renderer process. -->
+    <!-- All of the Node.js APIs are available in this renderer process. -->
     <div id="urim-plain-container">
         <canvas id="urim-plain"></canvas>
     </div>
@@ -42,11 +42,11 @@
             <!-- 以下にインプットタグをjsonから読み込んだ設定ファイルの値に動的に変更 -->
         </ul>
         <h6>ジャンル新規登録</h6>
-            <form name="form1" id="newGenre" action="">
-                <input type="color" id="newGenreColorPallet" name="createGenre" value="#e66465">
-                <input type="text" id="newGenreLabel" name="createGenre">
-                <input type="button" id="genreAdd" value="登録" />
-            </form>
+        <form name="form1" id="newGenre" action="">
+            <input type="color" id="newGenreColorPallet" name="createGenre" value="#e66465">
+            <input type="text" id="newGenreLabel" name="createGenre">
+            <input type="button" id="genreAdd" value="登録" />
+        </form>
         <h5>緊急度のスケール調整</h5>
 
         <label class="mdl-radio mdl-js-radio mdl-js-ripple-effect" for="option-1">
@@ -64,10 +64,29 @@
 
         <p><a id="modal-close" class="button-link">閉じる</a></p>
     </div>
+
     <!-- 2番目に表示されるモーダル（オーバーウエィ)半透明な膜 -->
-    <div id="modal-overlay" ></div>
+    <div id="modal-overlay"></div>
 
     <!-- モーダルウィンドウここまで -->
+
+    <!-- 詳細画面モーダル -->
+    <dialog id="detail-dialog" class="mdl-dialog">
+        <div class="mdl-dialog__content">
+            <div id="detail-title"></div>
+            <div id="detail-contents"></div>
+            <div id="detail-importance"></div>
+            <div id="detail-urgency"></div>
+            <div id="detail-deadline"></div>
+            <div id="detail-manHour"></div>
+            <div id="detail-genre"></div>
+            <div id="detail-place"></div>
+        </div>
+        <div class="mdl-dialog__actions">
+            <button type="button" class="mdl-button" id="close-detail-dialog-button">閉じる</button>
+        </div>
+    </dialog>
+    <!-- 詳細画面モーダルここまで -->
 
 </body>
 <script>

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -72,7 +72,14 @@
 
     <!-- 詳細画面モーダル -->
     <dialog id="detail-dialog" class="mdl-dialog">
+        <div class="mdl-dialog__actions">
+            <button class="mdl-button mdl-js-button mdl-button--icon" id="close-detail-dialog-button">
+                <i class="material-icons">close</i>
+            </button>
+        </div>
         <div class="mdl-dialog__content">
+            <i id="detail-today-star" class="fas fa-star" style="display:none;"></i>
+            <i id="detail-not-today-star" class="far fa-star" style="display:none;"></i>
             <div id="detail-title"></div>
             <div id="detail-contents"></div>
             <div id="detail-importance"></div>
@@ -82,9 +89,22 @@
             <div id="detail-genre"></div>
             <div id="detail-place"></div>
         </div>
-        <div class="mdl-dialog__actions">
-            <button type="button" class="mdl-button" id="close-detail-dialog-button">閉じる</button>
+        <div class="mdl-grid">
+            <div class="mdl-layout-spacer">
+                <button type="button"
+                    class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">編集</button>
+            </div>
+            <div class="mdl-layout-spacer">
+                <button type="button"
+                    class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">達成</button>
+            </div>
+            <div class="mdl-layout-spacer">
+                <button type="button"
+                    class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">削除</button>
+            </div>
         </div>
+
+
     </dialog>
     <!-- 詳細画面モーダルここまで -->
 

--- a/src/ts/ToDoTip.ts
+++ b/src/ts/ToDoTip.ts
@@ -1,4 +1,5 @@
 import ToDoData from './ToDoData';
+import settingsData from './settingsData';
 import Common from './common';
 
 /**
@@ -71,18 +72,14 @@ class ToDoTip {
      * @param canvas 
      * @param ctx 
      */
-    public toggleToday(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D) {
-        const common = new Common();
+    public toggleToday(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D, settingsData: settingsData) {
         this.toDoData.setToday(!this.toDoData.getIsToday());
         ctx.beginPath();
 
         // toDoDataの描画矩形の設定
+        // ジャンルIDに応じた背景色に設定する
         ctx.rect(this.left, this.top, this.width, this.height);
-        ctx.fillStyle = 'rgb(0, 0, 0)';
-        ctx.stroke();
-
-        ctx.fillStyle = common.backgroundColor[common.imToNum[this.toDoData.getImportance()]];
-
+        ctx.fillStyle = settingsData.getGenreData()[this.toDoData.getGenreId()]['color'];
         ctx.fill();
 
         // toDoDataの文字描画開始

--- a/src/ts/ToDoTip.ts
+++ b/src/ts/ToDoTip.ts
@@ -28,6 +28,9 @@ class ToDoTip {
     private text: TextPos;
     public shortTitle: string
     public toDoData: ToDoData;
+    public urgencyNumber: number;
+    public importanceNumber: number;
+    public fontScale: number;
 
     /**
      * todoデータをコピーする
@@ -86,7 +89,7 @@ class ToDoTip {
 
         // toDoDataの文字描画開始
         ctx.beginPath();
-        let fontSize = canvas.width / 80;
+        let fontSize = canvas.height * this.fontScale / this.importanceNumber;
 
         let todayIcon = '\uf005';
 
@@ -97,7 +100,7 @@ class ToDoTip {
         ctx.fillText(todayIcon, this.getTextPosition().x, this.getTextPosition().y);
 
         ctx.font = `900 ${fontSize}px 'Font Awesome 5 Free'`;
-        ctx.fillText(this.shortTitle, this.getTextPosition().x + this.width / 3, this.getTextPosition().y);
+        ctx.fillText(this.shortTitle, this.getTextPosition().x + ctx.measureText(todayIcon).width * 1.25, this.getTextPosition().y);
     }
 }
 

--- a/src/ts/ToDoTip.ts
+++ b/src/ts/ToDoTip.ts
@@ -23,7 +23,8 @@ class ToDoTip {
     public bottom: number;
     public width: number;
     public height: number;
-    public page: number;
+    public page: number;    // 存在するページ番号
+    public isOnPage: boolean;   // 今一番表示されているかどうか
     private text: TextPos;
     public shortTitle: string
     public toDoData: ToDoData;
@@ -63,6 +64,7 @@ class ToDoTip {
      * @param p クリック時のcanvas座標
      */
     public isClicked(p: { x: number, y: number }) {
+        if (!this.isOnPage) return false;
         return (this.left <= p.x && p.x <= this.right) && (this.top <= p.y && p.y <= this.bottom);
     }
 

--- a/src/ts/abstTest.ts
+++ b/src/ts/abstTest.ts
@@ -1,13 +1,11 @@
-import Common from './common';
 import ToDoDataManager from './toDoDataManager';
 import settingsDataManager from './settingsDataManager';
 
-const common = new Common();
 const tddm = new ToDoDataManager();
 const sdm = new settingsDataManager();
 
-let toDoDataArray = tddm.importFromLocalStorage();
+tddm.import();
 console.log(tddm.toDoDataArray);
 
-let settingsData = sdm.importFromLocalStorage();
+sdm.import();
 console.log(sdm.settingsData);

--- a/src/ts/common.ts
+++ b/src/ts/common.ts
@@ -12,7 +12,7 @@ class Common {
     public key = {
         toDoData: 'toDoDataArray',
         settingsData: 'settingsData'
-    }
+    };
 }
 
 export default Common;

--- a/src/ts/detailDialogManager.ts
+++ b/src/ts/detailDialogManager.ts
@@ -1,0 +1,63 @@
+import ToDoTip from './ToDoTip';
+import settingsData from './settingsData'
+
+/**
+ * 詳細ダイアログに表示するコンテンツを生成するクラス
+ */
+class DetailDialogManager {
+    private dialog: HTMLDialogElement;
+
+    /**
+     * 詳細ダイアログの取得と、閉じるボタンを押した際にダイアログを閉じるイベント処理を追加する
+     */
+    constructor() {
+        this.dialog = <HTMLDialogElement>document.getElementById('detail-dialog');
+        this.dialog.querySelector('#close-detail-dialog-button').addEventListener('click', () => {
+            this.dialog.close();
+        });
+    }
+
+    /**
+     * 工数が見やすくなるよう、0を表示しない
+     * 
+     * @param manHour 工数
+     */
+    private formatManHour(manHour: { [s: string]: number }) {
+        let formattedManHour = ''
+
+        if (manHour.year !== 0) {
+            formattedManHour += `${manHour.year}y`
+        }
+        if (manHour.month !== 0) {
+            formattedManHour += `${manHour.month}m`
+        }
+        if (manHour.day !== 0) {
+            formattedManHour += `${manHour.day}d`
+        }
+        if (manHour.hour !== 0) {
+            formattedManHour += `${manHour.hour}h`
+        }
+
+        return formattedManHour;
+    }
+
+    /**
+     * 詳細ダイアログ内に表示するコンテンツをDOM操作により変更する
+     * 
+     * @param toDoTip todoTipデータ
+     * @param settingsData settingsデータ
+     */
+    public renderContents(toDoTip: ToDoTip, settingsData: settingsData) {
+        this.dialog.showModal();
+        this.dialog.querySelector('#detail-title').textContent = `作業名：${toDoTip.toDoData.getTitle()}`;
+        this.dialog.querySelector('#detail-contents').textContent = `作業内容：${toDoTip.toDoData.getDetailData().getContents()}`;
+        this.dialog.querySelector('#detail-importance').textContent = `重要度：${toDoTip.toDoData.getImportance()}`;
+        this.dialog.querySelector('#detail-urgency').textContent = `緊急度：${toDoTip.toDoData.getUrgency()}`;
+        this.dialog.querySelector('#detail-deadline').textContent = `〆切：${toDoTip.toDoData.getDetailData().getDeadLine().year}/${toDoTip.toDoData.getDetailData().getDeadLine().month}/${toDoTip.toDoData.getDetailData().getDeadLine().day}`;
+        this.dialog.querySelector('#detail-manHour').textContent = `工数：${this.formatManHour(toDoTip.toDoData.getManHour())}`;
+        this.dialog.querySelector('#detail-genre').textContent = `ジャンル：${settingsData.getGenreData()[toDoTip.toDoData.getGenreId()]['name']} `;
+        this.dialog.querySelector('#detail-place').textContent = `場所：${toDoTip.toDoData.getDetailData().getPlace()} `;
+    }
+};
+
+export default DetailDialogManager;

--- a/src/ts/detailDialogManager.ts
+++ b/src/ts/detailDialogManager.ts
@@ -42,6 +42,23 @@ class DetailDialogManager {
     }
 
     /**
+     * 本日行うtodoかどうかを表す星を描画する
+     * 
+     * @param toDoTip toDoTipデータ
+     */
+    private renderStar(toDoTip: ToDoTip) {
+        if (toDoTip.toDoData.getIsToday()) {
+            this.dialog.querySelector('#detail-today-star').removeAttribute('style');
+            let deteilStarElement = <HTMLElement>this.dialog.querySelector('#detail-not-today-star');
+            deteilStarElement.style.display = 'none';
+        } else {
+            this.dialog.querySelector('#detail-not-today-star').removeAttribute('style');
+            let deteilStarElement = <HTMLElement>this.dialog.querySelector('#detail-today-star');
+            deteilStarElement.style.display = 'none';
+        }
+    }
+
+    /**
      * 詳細ダイアログ内に表示するコンテンツをDOM操作により変更する
      * 
      * @param toDoTip todoTipデータ
@@ -49,6 +66,7 @@ class DetailDialogManager {
      */
     public renderContents(toDoTip: ToDoTip, settingsData: settingsData) {
         this.dialog.showModal();
+        this.renderStar(toDoTip);
         this.dialog.querySelector('#detail-title').textContent = `作業名：${toDoTip.toDoData.getTitle()}`;
         this.dialog.querySelector('#detail-contents').textContent = `作業内容：${toDoTip.toDoData.getDetailData().getContents()}`;
         this.dialog.querySelector('#detail-importance').textContent = `重要度：${toDoTip.toDoData.getImportance()}`;

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -1,7 +1,30 @@
 import { app, BrowserWindow } from 'electron';
 import * as path from 'path';
+import ToDoDataManager from './toDoDataManager';
+import settingsDataManager from './settingsDataManager';
 
 let mainWindow: Electron.BrowserWindow;
+
+/**
+ * [ForDebugFunction]
+ * [デバッグ用関数]]
+ * electron-storeで管理しているtodoデータとsettingsデータをdata/*.jsonファイルの値にリセットする
+ */
+const resetAllDataForDebug = () => {
+    const tddm = new ToDoDataManager();
+    const sdm = new settingsDataManager();
+
+    tddm.resetDataForDebug();
+    sdm.resetDataForDebug();
+}
+
+/**
+ * アプリ起動後（readyイベントよりも先に呼ばれる）の処理
+ * [以下デバッグ用]
+ * 必要に応じてコメントをつけたり外したりしてください
+ * electron-storeで管理するデータをローカルjsonの値にリセットする関数を呼び出している
+ */
+// app.on("will-finish-launching", resetAllDataForDebug);
 
 function createWindow() {
     // Create the browser window.

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -7,7 +7,7 @@ let mainWindow: Electron.BrowserWindow;
 
 /**
  * [ForDebugFunction]
- * [デバッグ用関数]]
+ * [デバッグ用関数]
  * electron-storeで管理しているtodoデータとsettingsデータをdata/*.jsonファイルの値にリセットする
  */
 const resetAllDataForDebug = () => {

--- a/src/ts/pageManager.ts
+++ b/src/ts/pageManager.ts
@@ -2,7 +2,7 @@
  * 各セルの大きさや位置、ページを管理する
  */
 class PageManager {
-    public page: number;
+    public page: number;    // 現在のページ番号
     public minPage: number;
     public maxPage: number;
     public hasPages: boolean;

--- a/src/ts/renderer.ts
+++ b/src/ts/renderer.ts
@@ -115,15 +115,11 @@ canvas.addEventListener('click', e => {
 });
 
 /**
- * [未実装]
- * アプリ起動時にurim画面であった場合は、jsonからデータを読み込む
- * 他画面からの遷移時には、local storageからデータを読み込む
+ * html読み込み完了後、electron-storeからデータを読み込む
  * データ読み込み後に、描画処理
  */
 window.onload = () => {
     tddm.import();
-    // TODO: 2回目のアクセス移行は、下記方法でimportする
-    // tddm.importFromLocalStorage();
     sdm.import();
     render(tddm.toDoDataArray);
 };
@@ -139,8 +135,8 @@ const abstBtn = document.getElementById('abst-btn');
  * 概要モードボタンをクリックすると、概要モード画面へ遷移する
  */
 abstBtn.addEventListener('click', () => {
-    tddm.exportToLocalStorage();
-    sdm.exportToLocalStorage();
+    tddm.export();
+    sdm.export();
     location.href = '../html/abst.html';
 }, false);
 
@@ -150,7 +146,7 @@ const createBtn = document.getElementById('create-btn');
  * 作成ボタンをクリックすると、todo作成画面へ遷移する
  */
 createBtn.addEventListener('click', () => {
-    tddm.exportToLocalStorage();
-    sdm.exportToLocalStorage();
+    tddm.export();
+    sdm.export();
     location.href = '../html/form.html';
 }, false);

--- a/src/ts/renderer.ts
+++ b/src/ts/renderer.ts
@@ -43,7 +43,7 @@ canvas.addEventListener('contextmenu', e => {
         // TODO: upmにページ判定関数として定義する
         if (toDoTip.page == upm.urimCell[common.imToNum[<keyof { [s: string]: number }>toDoTip.toDoData.getImportance()]][upm.urToCoord(toDoTip.toDoData.getUrgency())].pm.page) {
             if (toDoTip.isClicked(point)) {
-                toDoTip.toggleToday(canvas, ctx);
+                toDoTip.toggleToday(canvas, ctx, sdm.settingsData);
             }
         }
     });

--- a/src/ts/renderer.ts
+++ b/src/ts/renderer.ts
@@ -4,8 +4,12 @@ import toDoData from './toDoData';
 import ToDoDataManager from './toDoDataManager';
 import Common from './common';
 import settingsDataManager from './settingsDataManager';
+import DetailDialogManager from './detailDialogManager';
+
 
 const canvas: HTMLCanvasElement = <HTMLCanvasElement>document.getElementById('urim-plain');
+
+const ddlgm = new DetailDialogManager();
 
 const tddm = new ToDoDataManager();
 
@@ -68,9 +72,7 @@ canvas.addEventListener('dblclick', e => {
     // クリック判定処理
     toDoTips.forEach(toDoTip => {
         if (toDoTip.isClicked(point)) {
-            // ToDo: 詳細画面に遷移する
-            // ToDoDataを渡すと詳細画面を描画するAPIが欲しい
-            console.log(toDoTip.toDoData.getDetailData());
+            ddlgm.renderContents(toDoTip, sdm.settingsData);
         }
     });
 

--- a/src/ts/settingsDataManager.ts
+++ b/src/ts/settingsDataManager.ts
@@ -3,17 +3,15 @@ import * as path from 'path';
 import settingsData from './settingsData';
 import LocalStorage from './localStorageManager';
 import Common from './common';
+import * as Store from 'electron-store';
 
 /**
 * This is a class for settingsData manager.
 * It contains urgencyScale and array of genre data.
 */
 export default class settingsDataManager {
-    //importとexportを分けているのは今後修正
-    private importGenreDataPathToFile: string;
-    private exportGenreDataPathToFile: string;
-    private importSettingsDataPathToFile: string;
-    private exportSettingsDataPathToFile: string;
+    private store: Store;
+    private common: Common;
     public settingsData: settingsData;
 
     /**
@@ -21,10 +19,8 @@ export default class settingsDataManager {
     * @param void
     */
     constructor() {
-        this.exportGenreDataPathToFile = path.resolve(__dirname, "../data/new/genreData.json");
-
-        this.importSettingsDataPathToFile = path.resolve(__dirname, "../data/settingsData.json");
-        this.exportSettingsDataPathToFile = path.resolve(__dirname, "../data/new/settingsData.json");
+        this.store = new Store();
+        this.common = new Common();
     }
 
     /**
@@ -34,24 +30,13 @@ export default class settingsDataManager {
     */
     public import() {
         try {
-            console.log('loading SettingsData JSON file...');
-            let settingsDataArray = JSON.parse(fs.readFileSync(this.importSettingsDataPathToFile, 'utf8'));
+            console.log('loading SettingsData by electron-store...');
+            let settingsDataArray = this.store.get(this.common.key.settingsData);
 
-            this.importGenreDataPathToFile = settingsDataArray[0]['genreData'];
-            let genreDataArray;
+            let genreDataArray = settingsDataArray.genreArray;
 
-            try {
-                console.log('loading GenreData JSON file...');
-
-                genreDataArray = JSON.parse(fs.readFileSync(path.resolve(__dirname, this.importGenreDataPathToFile), 'utf8'));
-            }
-            catch (e) {
-                console.log(e);
-                return false;
-            }
-            console.log("Loading GenreData Complete.");
-
-            this.settingsData = new settingsData(genreDataArray, Number(settingsDataArray[0]['urgencyScale']));
+            this.settingsData = new settingsData(genreDataArray, Number(settingsDataArray.urgencyScale));
+            console.log(this.settingsData);
         }
         catch (e) {
             console.log(e);
@@ -93,28 +78,15 @@ export default class settingsDataManager {
     */
     public export() {
         try {
-            console.log("exporting SettingData JSON file...");
-            let json_text = JSON.stringify(this.settingsData);
-            fs.writeFileSync(this.exportSettingsDataPathToFile, json_text);
-            console.log(json_text);
+            console.log("exporting SettingData by electron-store...");
+            this.store.set(this.common.key.settingsData, this.settingsData);
+            console.log(this.settingsData);
         }
         catch (e) {
             console.log(e);
             return false;
         }
-        console.log("Expoting SettingData Complete.")
-
-        try {
-            console.log("exporting GenreData JSON file...");
-            let json_text = JSON.stringify(this.settingsData.getGenreData());
-            fs.writeFileSync(this.exportGenreDataPathToFile, json_text);
-            console.log(json_text);
-        }
-        catch (e) {
-            console.log(e);
-            return false;
-        }
-        console.log("Expoting GenreData Complete.")
+        console.log("Expoting SettingData Complete.");
 
         return true;
     }
@@ -141,4 +113,42 @@ export default class settingsDataManager {
         return true;
     }
 
+    /**
+     * [For-Debug-Function]
+     * [デバッグ用関数]
+     * This is a function to reset all settings data to local json files.
+     */
+    public resetDataForDebug() {
+        try {
+            console.log('loading SettingsData JSON file...');
+            const importSettingsDataPathToFile = path.resolve(__dirname, "../data/settingsData.json");
+            let settingsDataArray = JSON.parse(fs.readFileSync(importSettingsDataPathToFile, 'utf8'));
+
+            const importGenreDataPathToFile = settingsDataArray[0]['genreData'];
+            let genreDataArray;
+
+            try {
+                console.log('loading GenreData JSON file...');
+
+                genreDataArray = JSON.parse(fs.readFileSync(path.resolve(__dirname, importGenreDataPathToFile), 'utf8'));
+            }
+            catch (e) {
+                console.log(e);
+                return false;
+            }
+            console.log("Loading GenreData Complete.");
+
+            this.settingsData = new settingsData(genreDataArray, Number(settingsDataArray[0]['urgencyScale']));
+
+            this.store.set(this.common.key.settingsData, this.settingsData);
+        }
+        catch (e) {
+            console.log(e);
+            return false;
+        }
+        console.log("Loading SettingsData Complete.")
+
+        return true;
+
+    }
 }

--- a/src/ts/settingsDataManager.ts
+++ b/src/ts/settingsDataManager.ts
@@ -30,7 +30,7 @@ export default class settingsDataManager {
     */
     public import() {
         try {
-            console.log('loading SettingsData by electron-store...');
+            console.log('Loading settings data by electron-store...');
             let settingsDataArray = this.store.get(this.common.key.settingsData);
 
             let genreDataArray = settingsDataArray.genreArray;
@@ -42,7 +42,7 @@ export default class settingsDataManager {
             console.log(e);
             return false;
         }
-        console.log("Loading SettingsData Complete.")
+        console.log("Completed settings data loading by electron-store.")
 
         return true;
     }
@@ -54,7 +54,7 @@ export default class settingsDataManager {
 */
     public importFromLocalStorage() {
         try {
-            console.log('loading SettingsData from local storage...');
+            console.log('Loading settings data from local storage...');
             const ls = new LocalStorage();
             const common = new Common();
 
@@ -66,7 +66,7 @@ export default class settingsDataManager {
             console.log(e);
             return false;
         }
-        console.log("Loading SettingsData Complete.")
+        console.log("Completed settings data loading from local storage.")
 
         return true;
     }
@@ -78,7 +78,7 @@ export default class settingsDataManager {
     */
     public export() {
         try {
-            console.log("exporting SettingData by electron-store...");
+            console.log("Exporting settings data by electron-store...");
             this.store.set(this.common.key.settingsData, this.settingsData);
             console.log(this.settingsData);
         }
@@ -86,7 +86,7 @@ export default class settingsDataManager {
             console.log(e);
             return false;
         }
-        console.log("Expoting SettingData Complete.");
+        console.log("Completed settings data expoting by electron-store.");
 
         return true;
     }
@@ -98,7 +98,7 @@ export default class settingsDataManager {
     */
     public exportToLocalStorage() {
         try {
-            console.log("exporting SettingData to local storage...");
+            console.log("Exporting settings data to local storage...");
             const ls = new LocalStorage();
             const common = new Common();
 
@@ -108,7 +108,7 @@ export default class settingsDataManager {
             console.log(e);
             return false;
         }
-        console.log("Expoting SettingData Complete.")
+        console.log("Completed settings data expoting to local storage.")
 
         return true;
     }
@@ -120,7 +120,7 @@ export default class settingsDataManager {
      */
     public resetDataForDebug() {
         try {
-            console.log('loading SettingsData JSON file...');
+            console.log('Resetting settings data...');
             const importSettingsDataPathToFile = path.resolve(__dirname, "../data/settingsData.json");
             let settingsDataArray = JSON.parse(fs.readFileSync(importSettingsDataPathToFile, 'utf8'));
 
@@ -128,7 +128,7 @@ export default class settingsDataManager {
             let genreDataArray;
 
             try {
-                console.log('loading GenreData JSON file...');
+                console.log('Resetting genre data...');
 
                 genreDataArray = JSON.parse(fs.readFileSync(path.resolve(__dirname, importGenreDataPathToFile), 'utf8'));
             }
@@ -136,7 +136,7 @@ export default class settingsDataManager {
                 console.log(e);
                 return false;
             }
-            console.log("Loading GenreData Complete.");
+            console.log("Completed genre data resetting.");
 
             this.settingsData = new settingsData(genreDataArray, Number(settingsDataArray[0]['urgencyScale']));
 
@@ -146,7 +146,7 @@ export default class settingsDataManager {
             console.log(e);
             return false;
         }
-        console.log("Loading SettingsData Complete.")
+        console.log("Completed settings data resetting.")
 
         return true;
 

--- a/src/ts/toDoDataManager.ts
+++ b/src/ts/toDoDataManager.ts
@@ -31,7 +31,7 @@ export default class toDoDataManager {
     */
     public import() {
         try {
-            console.log('loading file by electron-store...');
+            console.log('Loading todo data by electron-store...');
             let toDoDataArray = this.store.get(this.common.key.toDoData);
             console.log(toDoDataArray)
 
@@ -47,7 +47,7 @@ export default class toDoDataManager {
             console.log(e);
             return false;
         }
-        console.log('Complete.');
+        console.log('Completed todo data loading by electron-store.');
         return true;
     }
 
@@ -58,7 +58,7 @@ export default class toDoDataManager {
     */
     public importFromLocalStorage() {
         try {
-            console.log('loading local storage...');
+            console.log('Loading todo data from local storage...');
             const ls = new LocalStorage();
 
             let toDoDataArray = ls.getValue(this.common.key.toDoData);
@@ -75,7 +75,7 @@ export default class toDoDataManager {
             console.log(e);
             return false;
         }
-        console.log('Complete.');
+        console.log('Completed todo data loading from local storage.');
         return true;
     }
 
@@ -86,7 +86,7 @@ export default class toDoDataManager {
     */
     public export() {
         try {
-            console.log('exporting file by electron-store...');
+            console.log('Exporting todo data by electron-store...');
             this.store.set(this.common.key.toDoData, this.toDoDataArray);
             console.log(this.toDoDataArray);
         }
@@ -94,7 +94,7 @@ export default class toDoDataManager {
             console.log(e);
             return false;
         }
-        console.log('Complete.');
+        console.log('Completed todo data exporting by electron-store.');
         return true;
     }
 
@@ -105,7 +105,7 @@ export default class toDoDataManager {
     */
     public exportToLocalStorage() {
         try {
-            console.log('exporting to local storage...');
+            console.log('Exporting todo data to local storage...');
             const ls = new LocalStorage();
 
             ls.setValue(this.common.key.toDoData, this.toDoDataArray);
@@ -114,7 +114,7 @@ export default class toDoDataManager {
             console.log(e);
             return false;
         }
-        console.log('Complete.');
+        console.log('Completed todo data exporting to local storage.');
         return true;
     }
 
@@ -147,7 +147,7 @@ export default class toDoDataManager {
         try {
             const importPathToFile = path.resolve(__dirname, '../data/todoData.json');
 
-            console.log('loading JSON file...');
+            console.log('Resetting todo data...');
             let toDoDataArray = JSON.parse(fs.readFileSync(importPathToFile, 'utf8'));
 
             for (let index in toDoDataArray) {
@@ -165,7 +165,7 @@ export default class toDoDataManager {
             console.log(e);
             return false;
         }
-        console.log('Complete.');
+        console.log('Completed todo data resetting.');
         return true;
     }
 }

--- a/src/ts/urimPlaneManager.ts
+++ b/src/ts/urimPlaneManager.ts
@@ -21,6 +21,13 @@ export class UrimPlaneManager {
     private sdm: settingsDataManager;
     public urimCell: UrimCell[][]; // 4 * 20の要素　各要素に入るデータ数は異なる
     // cell[importance][urgency].ids[index]: 各importance, urgencyでのtoDoデータIDを格納する
+    private widthPartitionPerSpan: number;
+    private urgencySpans: number[];
+    private heightPartitionPerImportance: number;   // 表示セル数 + 2（1はページ管理用ボタンで1は余白用）
+    private importanceNumber: number;
+    private urgencyNumber: number;
+    private fontScale: number;
+    private widthScale: number;
 
     /**
      * 4 * 20のセルを作成する
@@ -28,11 +35,18 @@ export class UrimPlaneManager {
     constructor() {
         this.sdm = new settingsDataManager();
         this.sdm.import();
+        this.urgencySpans = [21, 33, 81, 240];
+        this.widthPartitionPerSpan = 2;
+        this.heightPartitionPerImportance = 5;
+        this.importanceNumber = 4 * this.heightPartitionPerImportance;
+        this.urgencyNumber = this.widthPartitionPerSpan * this.urgencySpans.length;
+        this.fontScale = 0.6;
+        this.widthScale = 0.9;
 
-        this.urimCell = new Array(4);
-        for (let iIm = 0; iIm < 4; iIm++) {
-            this.urimCell[iIm] = new Array(20);
-            for (let iUr = 0; iUr < 20; iUr++) {
+        this.urimCell = new Array(this.importanceNumber);
+        for (let iIm = 0; iIm < this.importanceNumber; iIm++) {
+            this.urimCell[iIm] = new Array(this.urgencyNumber);
+            for (let iUr = 0; iUr < this.urgencyNumber; iUr++) {
                 this.urimCell[iIm][iUr] = {
                     ids: [''],
                     pm: new PageManager()
@@ -64,15 +78,15 @@ export class UrimPlaneManager {
 
         ctx.scale(dpr, dpr);
 
-        for (let iIm = 0; iIm < 4; iIm++) {
-            for (let iUr = 0; iUr < 20; iUr++) {
+        for (let iIm = 0; iIm < this.importanceNumber; iIm++) {
+            for (let iUr = 0; iUr < this.urgencyNumber; iUr++) {
                 this.urimCell[iIm][iUr].ids = [''];
                 this.urimCell[iIm][iUr].pm.maxPage = 0;
                 this.urimCell[iIm][iUr].pm.minPage = 0;
-                this.urimCell[iIm][iUr].pm.left = iUr * canvas.width / 20;;
-                this.urimCell[iIm][iUr].pm.width = canvas.width / 20;
-                this.urimCell[iIm][iUr].pm.height = canvas.height / 32;
-                this.urimCell[iIm][iUr].pm.top = this.calcImCoord(canvas, Object.keys(common.imToNum).filter(v => { return common.imToNum[v] == iIm })[0]) + 6 * this.urimCell[iIm][iUr].pm.height - this.urimCell[iIm][iUr].pm.height;
+                this.urimCell[iIm][iUr].pm.left = iUr * canvas.width / this.urgencyNumber + canvas.width * (1 - this.widthScale) / (this.urgencyNumber * 2);
+                this.urimCell[iIm][iUr].pm.width = canvas.width * this.widthScale / this.urgencyNumber;
+                this.urimCell[iIm][iUr].pm.height = canvas.height / this.importanceNumber;
+                this.urimCell[iIm][iUr].pm.top = this.calcImCoord(canvas, Object.keys(common.imToNum).filter(v => { return common.imToNum[v] == iIm })[0]) + (this.heightPartitionPerImportance - 2) * this.urimCell[iIm][iUr].pm.height;
             }
         }
 
@@ -87,19 +101,17 @@ export class UrimPlaneManager {
      * @param urgency 緊急度（現状[要検討]20分割している）
      */
     public urToCoord(urgency: number) {
-        if (urgency >= 1 && urgency <= 5) {
-            return 20 - urgency;
-        }
-        else if (urgency >= 6 && urgency <= 30) {
-            return (urgency - 5) % 5 !== 0 ? 20 - 6 - Math.floor((urgency - 5) / 5) : 20 - 5 - Math.floor((urgency - 5) / 5);
-        }
-        else if (urgency >= 31 && urgency <= 90) {
-            return (urgency - 30) % 12 !== 0 ? 20 - 11 - Math.floor((urgency - 30) / 12) : 20 - 10 - Math.floor((urgency - 30) / 12);
-        }
-        else if (urgency >= 91 && urgency <= 242) {
-            return (urgency - 90) % 30 !== 0 ? 20 - 16 - Math.floor((urgency - 90) / 30) : 20 - 15 - Math.floor((urgency - 90) / 30);
-        }
-        else if (urgency >= 243) {
+        if (urgency <= 0) {
+            return this.urgencyNumber - 1;
+        } else if (urgency >= 1 && urgency <= this.urgencySpans[0]) {
+            return this.urgencyNumber - 1 - Math.floor((urgency - 1) * this.widthPartitionPerSpan / this.urgencySpans[0]);
+        } else if (urgency >= this.urgencySpans[0] + 1 && urgency <= this.urgencySpans[1]) {
+            return this.urgencyNumber - this.widthPartitionPerSpan - 1 - Math.floor((urgency - this.urgencySpans[0] - 1) * this.widthPartitionPerSpan / this.urgencySpans[1]);
+        } else if (urgency >= this.urgencySpans[1] + 1 && urgency <= this.urgencySpans[2]) {
+            return this.urgencyNumber - 2 * this.widthPartitionPerSpan - 1 - Math.floor((urgency - this.urgencySpans[0] - this.urgencySpans[1] - 1) * this.widthPartitionPerSpan / this.urgencySpans[2]);
+        } else if (urgency >= this.urgencySpans[2] + 1 && urgency <= this.urgencySpans[3]) {
+            return this.urgencyNumber - 3 * this.widthPartitionPerSpan - 1 - Math.floor((urgency - this.urgencySpans[0] - this.urgencySpans[1] - this.urgencySpans[2] - 1) * this.widthPartitionPerSpan / this.urgencySpans[3]);
+        } else if (urgency >= this.urgencySpans[3] + 1) {
             return 0;
         }
     }
@@ -112,7 +124,7 @@ export class UrimPlaneManager {
      */
     private calcImCoord(canvas: HTMLCanvasElement, importance: string): number {
         const common = new Common();
-        return canvas.height * common.imToNum[<keyof { [s: string]: number }>importance] / 4 + canvas.height / 20;
+        return canvas.height * common.imToNum[<keyof { [s: string]: number }>importance] / 4 + canvas.height / (2 * this.importanceNumber);
     }
 
     /**
@@ -122,7 +134,7 @@ export class UrimPlaneManager {
      * @param urgency 緊急度
      */
     private calcUrCoord(canvas: HTMLCanvasElement, urgency: number): number {
-        return this.urToCoord(urgency) * canvas.width / 20;
+        return this.urToCoord(urgency) * canvas.width / this.urgencyNumber;
     }
 
     /**
@@ -170,12 +182,13 @@ export class UrimPlaneManager {
                         // を計算する
                         let toDoTip = new ToDoTip(toDoData);
 
-                        toDoTip.width = canvas.width / 20;
-                        toDoTip.height = canvas.height / 32;
-                        toDoTip.left = this.calcUrCoord(canvas, toDoData.getUrgency());
-                        toDoTip.bottom = this.calcImCoord(canvas, toDoData.getImportance()) + (index % 6) * toDoTip.height;
+                        toDoTip.width = canvas.width * this.widthScale / this.urgencyNumber;
+                        toDoTip.height = canvas.height / this.importanceNumber;
+                        toDoTip.left = this.calcUrCoord(canvas, toDoData.getUrgency()) + (canvas.width / this.urgencyNumber - toDoTip.width) / 2;
+                        toDoTip.top = this.calcImCoord(canvas, toDoData.getImportance()) + (index % (this.heightPartitionPerImportance - 2)) * toDoTip.height;
+                        toDoTip.bottom = toDoTip.top + toDoTip.height;
 
-                        toDoTip.page = Math.floor(index / 6);
+                        toDoTip.page = Math.floor(index / (this.heightPartitionPerImportance - 2));
 
                         if (toDoTip.page == 0) {
                             toDoTip.isOnPage = true;
@@ -186,15 +199,18 @@ export class UrimPlaneManager {
                         // 最大ページを求める
                         this.urimCell[common.imToNum[<keyof { [s: string]: number }>toDoData.getImportance()]][this.urToCoord(toDoData.getUrgency())].pm.maxPage = Math.max(this.urimCell[common.imToNum[<keyof { [s: string]: number }>toDoData.getImportance()]][this.urToCoord(toDoData.getUrgency())].pm.maxPage, toDoTip.page);
 
-                        if (index > 6) {
+                        if (index > (this.heightPartitionPerImportance - 2)) {
                             this.urimCell[common.imToNum[<keyof { [s: string]: number }>toDoData.getImportance()]][this.urToCoord(toDoData.getUrgency())].pm.hasPages = true;
-                        } else if (index <= 6) {
+                        } else if (index <= (this.heightPartitionPerImportance - 2)) {
                             this.urimCell[common.imToNum[<keyof { [s: string]: number }>toDoData.getImportance()]][this.urToCoord(toDoData.getUrgency())].pm.hasPages = false;
                         }
 
                         toDoTip.right = toDoTip.left + toDoTip.width;
-                        toDoTip.top = toDoTip.bottom - toDoTip.height;
-                        toDoTip.setTextPosition(toDoTip.left, toDoTip.top + canvas.height / 40);
+                        toDoTip.setTextPosition(toDoTip.left, toDoTip.top + toDoTip.height * (1 - this.fontScale) / 2);
+
+                        toDoTip.urgencyNumber = this.urgencyNumber;
+                        toDoTip.importanceNumber = this.importanceNumber;
+                        toDoTip.fontScale = this.fontScale;
 
                         toDoTips.push(toDoTip);
                     });
@@ -271,7 +287,7 @@ export class UrimPlaneManager {
 
         // toDoDataの文字描画開始
         ctx.beginPath();
-        let fontSize = canvas.width / 80;
+        let fontSize = canvas.height * this.fontScale / this.importanceNumber;
 
         // today用の星描画
         let todayIcon = '\uf005';
@@ -280,6 +296,7 @@ export class UrimPlaneManager {
 
         ctx.fillStyle = 'rgb(0, 0, 0)';
 
+        ctx.textBaseline = 'top';
         ctx.fillText(todayIcon, toDoTip.getTextPosition().x, toDoTip.getTextPosition().y);
 
         ctx.font = `900 ${fontSize}px 'Font Awesome 5 Free'`;
@@ -287,9 +304,10 @@ export class UrimPlaneManager {
         let title = toDoTip.toDoData.getTitle();
         toDoTip.shortTitle = title;
 
-        if (ctx.measureText(todayIcon + title).width >= toDoTip.width) {
+        if (ctx.measureText(todayIcon).width * 1.25 + ctx.measureText(title).width >= toDoTip.width) {
+            console.log('超えた', toDoTip.shortTitle);
             while (true) {
-                if (ctx.measureText(`${todayIcon}${title}..`).width < toDoTip.width) {
+                if (ctx.measureText(todayIcon).width * 1.25 + ctx.measureText(`${title}..`).width < toDoTip.width) {
                     toDoTip.shortTitle = title + '..';
                     break;
                 }
@@ -297,7 +315,8 @@ export class UrimPlaneManager {
             }
         }
 
-        ctx.fillText(toDoTip.shortTitle, toDoTip.getTextPosition().x + toDoTip.width / 3, toDoTip.getTextPosition().y);
+        ctx.textBaseline = 'top';
+        ctx.fillText(toDoTip.shortTitle, toDoTip.getTextPosition().x + ctx.measureText(todayIcon).width * 1.25, toDoTip.getTextPosition().y);
     }
 
     /**
@@ -323,19 +342,18 @@ export class UrimPlaneManager {
      */
     private renderPageController(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D) {
         for (let iIm = 0; iIm < 4; iIm++) {
-            for (let iUr = 0; iUr < 20; iUr++) {
+            for (let iUr = 0; iUr < this.urgencyNumber; iUr++) {
                 if (this.urimCell[iIm][iUr].pm.hasPages) {
-                    ctx.fillStyle = '#000';
-                    ctx.rect(this.urimCell[iIm][iUr].pm.left, this.urimCell[iIm][iUr].pm.top, this.urimCell[iIm][iUr].pm.width, this.urimCell[iIm][iUr].pm.height);
-                    ctx.stroke();
-
                     // 矢印描画
-                    let fontSize = canvas.width / 60;
+                    let fontSize = canvas.height / this.importanceNumber;
                     ctx.font = `900 ${fontSize}px 'Font Awesome 5 Free'`;
                     ctx.fillStyle = 'rgb(0, 0, 0)';
 
-                    ctx.fillText('\uf0d9', this.urimCell[iIm][iUr].pm.left + this.urimCell[iIm][iUr].pm.width / 10, this.urimCell[iIm][iUr].pm.top + canvas.height / 40);
-                    ctx.fillText('\uf0da', this.urimCell[iIm][iUr].pm.left + this.urimCell[iIm][iUr].pm.width * 8 / 10, this.urimCell[iIm][iUr].pm.top + canvas.height / 40);
+                    ctx.textBaseline = 'top';
+                    ctx.fillText('\uf0d9', this.urimCell[iIm][iUr].pm.left, this.urimCell[iIm][iUr].pm.top);
+                    ctx.textAlign = 'end';
+                    ctx.fillText('\uf0da', this.urimCell[iIm][iUr].pm.left + this.urimCell[iIm][iUr].pm.width, this.urimCell[iIm][iUr].pm.top);
+                    ctx.textAlign = 'start';
                 }
             }
         }

--- a/src/ts/urimPlaneManager.ts
+++ b/src/ts/urimPlaneManager.ts
@@ -177,6 +177,12 @@ export class UrimPlaneManager {
 
                         toDoTip.page = Math.floor(index / 6);
 
+                        if (toDoTip.page == 0) {
+                            toDoTip.isOnPage = true;
+                        } else {
+                            toDoTip.isOnPage = false;
+                        }
+
                         // 最大ページを求める
                         this.urimCell[common.imToNum[<keyof { [s: string]: number }>toDoData.getImportance()]][this.urToCoord(toDoData.getUrgency())].pm.maxPage = Math.max(this.urimCell[common.imToNum[<keyof { [s: string]: number }>toDoData.getImportance()]][this.urToCoord(toDoData.getUrgency())].pm.maxPage, toDoTip.page);
 
@@ -354,6 +360,9 @@ export class UrimPlaneManager {
         toDoTips.forEach(toDoTip => {
             if (toDoTip.page == this.urimCell[common.imToNum[<keyof { [s: string]: number }>toDoTip.toDoData.getImportance()]][this.urToCoord(toDoTip.toDoData.getUrgency())].pm.page) {
                 this.renderToDo(toDoTip, canvas, ctx);
+                toDoTip.isOnPage = true;
+            } else {
+                toDoTip.isOnPage = false;
             }
         });
 

--- a/src/ts/urimPlaneManager.ts
+++ b/src/ts/urimPlaneManager.ts
@@ -3,6 +3,7 @@ import ToDoData from './ToDoData';
 import ToDoTip from './ToDoTip';
 import Common from './common';
 import PageManager from './pageManager';
+import settingsDataManager from './settingsDataManager';
 
 export interface UrimCell {
     ids: string[],
@@ -17,6 +18,7 @@ export class UrimPlaneManager {
     public imAxis: AxisManager;
     private height: number;
     private width: number;
+    private sdm: settingsDataManager;
     public urimCell: UrimCell[][]; // 4 * 20の要素　各要素に入るデータ数は異なる
     // cell[importance][urgency].ids[index]: 各importance, urgencyでのtoDoデータIDを格納する
 
@@ -24,6 +26,9 @@ export class UrimPlaneManager {
      * 4 * 20のセルを作成する
      */
     constructor() {
+        this.sdm = new settingsDataManager();
+        this.sdm.import();
+
         this.urimCell = new Array(4);
         for (let iIm = 0; iIm < 4; iIm++) {
             this.urimCell[iIm] = new Array(20);
@@ -253,9 +258,9 @@ export class UrimPlaneManager {
         ctx.rect(toDoTip.left, toDoTip.top, toDoTip.width, toDoTip.height);
 
         // toDoDataの色設定
-        // todayかどうかで色が決まる
-        ctx.fillStyle = 'rgb(0, 0, 0)';
-        ctx.stroke();
+        // ジャンルIDに応じた背景色に設定する
+        ctx.fillStyle = this.sdm.settingsData.getGenreData()[toDoTip.toDoData.getGenreId()]['color'];
+        ctx.fill();
 
 
         // toDoDataの文字描画開始


### PR DESCRIPTION
- jsonやlocalstorage管理からelectron-storeに乗り換え
  - ### **pull後、初回に`main.ts`のelectron-storeにデータ移行するreset関数をコメントアウトしてください**
- UI一部変更
  - todoセルサイズを可変
  - todoページ変更の矢印枠の削除
  - セル間に余白追加
  - ジャンルカラーをセル背景に適用
- 詳細画面の追加
  - todoをダブルクリックしたら詳細ダイアログが表示
  - 詳細画面をMDL化