### PR TITLE
既存データの読み込み時にはID変更しないようにする

### DIFF
--- a/data/genreData.json
+++ b/data/genreData.json
@@ -1,16 +1,16 @@
 [
     {
-        "id": 0,
+        "id": "TWM9ht7aVB",
         "color": "#d7c447",
         "name": "work"
     },
     {
-        "id": 1,
+        "id": "qKmfywGL6U",
         "color": "#00ac9b",
         "name": "school"
     },
     {
-        "id": 2,
+        "id": "1HHjvvCykP",
         "color": "#b6007a",
         "name": "house"
     }

--- a/data/todoData.json
+++ b/data/todoData.json
@@ -1,5 +1,6 @@
 [
     {
+        "id": "ATy3DH8N22",
         "title": "0:S2",
         "importance": "S",
         "manHour": {
@@ -8,7 +9,7 @@
             "day": 3,
             "hour": 10
         },
-        "genreId": 1,
+        "genreId": "qKmfywGL6U",
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -19,6 +20,7 @@
         "today": true
     },
     {
+        "id": "V7QY1UwVLG",
         "title": "1:A2",
         "importance": "A",
         "manHour": {
@@ -27,7 +29,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 2,
+        "genreId": "1HHjvvCykP",
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -38,6 +40,7 @@
         "today": false
     },
     {
+        "id": "t5nSRsRC9y",
         "title": "2:A2",
         "importance": "A",
         "manHour": {
@@ -46,7 +49,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 0,
+        "genreId": "TWM9ht7aVB",
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -57,6 +60,7 @@
         "today": false
     },
     {
+        "id": "cNQ6Jrqoxo",
         "title": "3:A2",
         "importance": "A",
         "manHour": {
@@ -65,7 +69,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 0,
+        "genreId": "TWM9ht7aVB",
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -76,6 +80,7 @@
         "today": false
     },
     {
+        "id": "PKpLuu2tyy",
         "title": "4:A2",
         "importance": "A",
         "manHour": {
@@ -84,7 +89,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 1,
+        "genreId": "qKmfywGL6U",
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -95,6 +100,7 @@
         "today": false
     },
     {
+        "id": "B2ucGW5qUq",
         "title": "5:A2",
         "importance": "A",
         "manHour": {
@@ -103,7 +109,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 0,
+        "genreId": "TWM9ht7aVB",
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -114,6 +120,7 @@
         "today": false
     },
     {
+        "id": "d7y3w4sD5u",
         "title": "6:A2",
         "importance": "A",
         "manHour": {
@@ -122,7 +129,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 2,
+        "genreId": "1HHjvvCykP",
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -133,6 +140,7 @@
         "today": false
     },
     {
+        "id": "64ATg9mLHh",
         "title": "7:A2",
         "importance": "A",
         "manHour": {
@@ -141,7 +149,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 0,
+        "genreId": "TWM9ht7aVB",
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -152,6 +160,7 @@
         "today": false
     },
     {
+        "id": "9Dmac6YP8S",
         "title": "8:A2",
         "importance": "A",
         "manHour": {
@@ -160,7 +169,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 1,
+        "genreId": "qKmfywGL6U",
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -171,6 +180,7 @@
         "today": false
     },
     {
+        "id": "OdlTVvgJTZ",
         "title": "9:A2",
         "importance": "A",
         "manHour": {
@@ -179,7 +189,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 0,
+        "genreId": "TWM9ht7aVB",
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -190,6 +200,7 @@
         "today": false
     },
     {
+        "id": "DvGST3uiY5",
         "title": "10:A2",
         "importance": "A",
         "manHour": {
@@ -198,7 +209,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 0,
+        "genreId": "TWM9ht7aVB",
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -209,6 +220,7 @@
         "today": false
     },
     {
+        "id": "9b4XUL9no2",
         "title": "11:A2",
         "importance": "A",
         "manHour": {
@@ -217,7 +229,7 @@
             "day": 12,
             "hour": 0
         },
-        "genreId": 2,
+        "genreId": "1HHjvvCykP",
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -228,6 +240,7 @@
         "today": false
     },
     {
+        "id": "f94TbDVjwM",
         "title": "12:A2",
         "importance": "B",
         "manHour": {
@@ -236,7 +249,7 @@
             "day": 10,
             "hour": 3
         },
-        "genreId": 0,
+        "genreId": "TWM9ht7aVB",
         "contents": "work at the office.",
         "deadline": {
             "year": 2019,
@@ -247,6 +260,7 @@
         "today": false
     },
     {
+        "id": "sa0oFAdZro",
         "title": "13:A2",
         "importance": "B",
         "manHour": {
@@ -255,7 +269,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 2,
+        "genreId": "1HHjvvCykP",
         "contents": "work at the office.",
         "deadline": {
             "year": 2020,
@@ -266,6 +280,7 @@
         "today": false
     },
     {
+        "id": "kIJKxtMbO5",
         "title": "14:C6",
         "importance": "C",
         "manHour": {
@@ -274,7 +289,7 @@
             "day": 1,
             "hour": 0
         },
-        "genreId": 0,
+        "genreId": "TWM9ht7aVB",
         "contents": "work at the office.",
         "deadline": {
             "year": 2020,
@@ -285,6 +300,7 @@
         "today": false
     },
     {
+        "id": "IqdsTL9fo4",
         "title": "15:A11",
         "importance": "A",
         "manHour": {
@@ -293,7 +309,7 @@
             "day": 0,
             "hour": 3
         },
-        "genreId": 1,
+        "genreId": "qKmfywGL6U",
         "contents": "work at the office.",
         "deadline": {
             "year": 2020,

--- a/src/ts/ToDoTip.ts
+++ b/src/ts/ToDoTip.ts
@@ -84,7 +84,9 @@ class ToDoTip {
         // toDoDataの描画矩形の設定
         // ジャンルIDに応じた背景色に設定する
         ctx.rect(this.left, this.top, this.width, this.height);
-        ctx.fillStyle = settingsData.getGenreData()[this.toDoData.getGenreId()]['color'];
+        ctx.fillStyle = settingsData.getGenreData().find(gd => {
+            return gd['id'] === this.toDoData.getGenreId();
+        })['color'];
         ctx.fill();
 
         // toDoDataの文字描画開始

--- a/src/ts/detailDialogManager.ts
+++ b/src/ts/detailDialogManager.ts
@@ -73,7 +73,9 @@ class DetailDialogManager {
         this.dialog.querySelector('#detail-urgency').textContent = `緊急度：${toDoTip.toDoData.getUrgency()}`;
         this.dialog.querySelector('#detail-deadline').textContent = `〆切：${toDoTip.toDoData.getDetailData().getDeadLine().year}/${toDoTip.toDoData.getDetailData().getDeadLine().month}/${toDoTip.toDoData.getDetailData().getDeadLine().day}`;
         this.dialog.querySelector('#detail-manHour').textContent = `工数：${this.formatManHour(toDoTip.toDoData.getManHour())}`;
-        this.dialog.querySelector('#detail-genre').textContent = `ジャンル：${settingsData.getGenreData()[toDoTip.toDoData.getGenreId()]['name']} `;
+        this.dialog.querySelector('#detail-genre').textContent = `ジャンル：${settingsData.getGenreData().find(gd => {
+            return gd['id'] === toDoTip.toDoData.getGenreId();
+        })['name']} `;
         this.dialog.querySelector('#detail-place').textContent = `場所：${toDoTip.toDoData.getDetailData().getPlace()} `;
     }
 };

--- a/src/ts/genreData.ts
+++ b/src/ts/genreData.ts
@@ -9,11 +9,20 @@ export default class genreData {
 
     /**
     * This is a constructor.
-    * @param color
-    * @param name
+    * @param color genre color.
+    * @param name genre name.
+    * @param id OPTION: genre ID.
     */
-    constructor(color: string, name: string) {
-        this.id = this.generateId();
+    constructor(color: string, name: string);
+    constructor(color: string, name: string, id: string);
+    constructor(color: string, name: string, id?: string) {
+        if (id === undefined) {
+            this.id = this.generateId();
+            console.log("genreID生成");
+        } else {
+            this.id = id;
+            console.log("genreID読み込み");
+        }
         this.color = color;
         this.name = name;
     }
@@ -23,7 +32,7 @@ export default class genreData {
     * @param void
     * @returns id
     */
-    private generateId() {
+    private generateId(): string {
         // characters which is used as id
         var str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
@@ -44,7 +53,7 @@ export default class genreData {
     * @param void
     * @returns id
     */
-    public getId() {
+    public getId(): string {
         return this.id;
     }
 
@@ -53,7 +62,7 @@ export default class genreData {
     * @param void
     * @returns color
     */
-    public getColor() {
+    public getColor(): string {
         return this.color;
     }
 
@@ -62,7 +71,7 @@ export default class genreData {
     * @param void
     * @returns name
     */
-    public getName() {
+    public getName(): string {
         return this.name;
     }
 

--- a/src/ts/toDoCreator.ts
+++ b/src/ts/toDoCreator.ts
@@ -21,7 +21,7 @@ interface FormItems {
     title: string;
     importance: string;
     manHour: ManHour;
-    genreId: number;
+    genreId: string;
     contents: string;
     deadline: Deadline;
     place: string;
@@ -34,9 +34,9 @@ window.onload = () => {
     sdm.importFromLocalStorage();
     console.log(sdm.settingsData);
     let gArray = new Array();
-    const gDataObj =  sdm.settingsData.getGenreData();
-    for (let i=0; i<gDataObj.length; i++) {
-        gArray[i] = new genreData(gDataObj[i]["color"], gDataObj[i]["name"]);
+    const gDataObj = sdm.settingsData.getGenreData();
+    for (let i = 0; i < gDataObj.length; i++) {
+        gArray[i] = new genreData(gDataObj[i]["color"], gDataObj[i]["name"], gDataObj[i]["id"]);
     }
     updateGenreData(gArray);
 };
@@ -74,7 +74,7 @@ function getTaskInfo(): FormItems {
     const importance = getImportance();
     // manHour: 工数(ManHour)
     const manHour = getManHour();
-    // genreId: タスク内容のジャンル(number)
+    // genreId: タスク内容のジャンル(string)
     const genreId = getGenreId();
     // contents: タスク内容
     const contents = getContents();
@@ -107,7 +107,7 @@ function registerTask(items: FormItems) {
         items.title, items.importance,
         items.manHour as any, items.genreId, items.deadline as any,
         items.contents, items.place, items.isToday);
-    
+
     // toDoDataArrayの末尾にtoDoDataを追加しexport
     const tddm = new ToDoDataManager();
     tddm.importFromLocalStorage();
@@ -126,7 +126,7 @@ function getImportance(): string {
 function getManHour(): ManHour {
     const hour = (document.getElementById("man_hour") as HTMLInputElement).value;
     // TODO: other form
-    const manHour:ManHour = {
+    const manHour: ManHour = {
         year: 0,
         month: 0,
         day: 0,
@@ -135,9 +135,8 @@ function getManHour(): ManHour {
     return manHour;
 }
 
-function getGenreId(): number {
-    const genre = (document.getElementById("genre") as HTMLInputElement).value;
-    return parseInt(genre);
+function getGenreId(): string {
+    return (document.getElementById("genre") as HTMLInputElement).value;
 }
 
 function getContents(): string {
@@ -147,7 +146,7 @@ function getContents(): string {
 function getDeadline(): Deadline {
     const date = (document.getElementById("deadline") as HTMLInputElement).value;
     const dateData = new Date(date);
-    const deadLine:Deadline = {
+    const deadLine: Deadline = {
         year: dateData.getFullYear(),
         month: dateData.getMonth(),
         day: dateData.getDay(),

--- a/src/ts/toDoData.ts
+++ b/src/ts/toDoData.ts
@@ -11,9 +11,10 @@ export default class toDoData {
     private importance: string;
     private urgency: number;
     private manHour: { [s: string]: number };
-    private genreId: number;
+    private genreId: string;
     private detailData: detailData;
     private isToday: boolean;
+
 
     /**
     * This is a constructor.
@@ -26,10 +27,21 @@ export default class toDoData {
     * @param content - TODO item's content.
     * @param place - Place where you do this action.
     * @param today - A flag whether you should do this action today.
+    * @param id - OPTION: TODO id.
     */
-    constructor(title: string, importance: string, manHour: { [s: string]: number }, genreId: number,
-        deadline: { [s: string]: number }, contents: string, place: string, isToday: boolean) {
-        this.id = this.generateId();
+    constructor(title: string, importance: string, manHour: { [s: string]: number }, genreId: string,
+        deadline: { [s: string]: number }, contents: string, place: string, isToday: boolean);
+    constructor(title: string, importance: string, manHour: { [s: string]: number }, genreId: string,
+        deadline: { [s: string]: number }, contents: string, place: string, isToday: boolean, id: string);
+    constructor(title: string, importance: string, manHour: { [s: string]: number }, genreId: string,
+        deadline: { [s: string]: number }, contents: string, place: string, isToday: boolean, id?: string) {
+        if (id === undefined) {
+            this.id = this.generateId();
+            console.log('todoID生成');
+        } else {
+            this.id = id;
+            console.log('todoID読み込み');
+        }
         this.title = title;
         this.importance = importance;
         this.manHour = manHour;
@@ -44,7 +56,7 @@ export default class toDoData {
     * @param void
     * @returns id
     */
-    private generateId() {
+    private generateId(): string {
         // characters which is used as id
         var str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
@@ -110,7 +122,7 @@ export default class toDoData {
     * @param void
     * @returns genreId
     */
-    public getGenreId(): number {
+    public getGenreId(): string {
         return this.genreId;
     }
 

--- a/src/ts/toDoDataManager.ts
+++ b/src/ts/toDoDataManager.ts
@@ -37,7 +37,7 @@ export default class toDoDataManager {
 
             for (let index in toDoDataArray) {
                 let tmpToDoData = toDoDataArray[index];
-                let data = new toDoData(tmpToDoData.title, tmpToDoData.importance, tmpToDoData.manHour, tmpToDoData.genreId, tmpToDoData.detailData.deadline, tmpToDoData.detailData.contents, tmpToDoData.detailData.place, tmpToDoData.isToday);
+                let data = new toDoData(tmpToDoData.title, tmpToDoData.importance, tmpToDoData.manHour, tmpToDoData.genreId, tmpToDoData.detailData.deadline, tmpToDoData.detailData.contents, tmpToDoData.detailData.place, tmpToDoData.isToday, tmpToDoData.id);
                 this.toDoDataArray.push(data);
             }
 
@@ -155,7 +155,7 @@ export default class toDoDataManager {
                 let data = new toDoData(tmpToDoData['title'], tmpToDoData['importance'],
                     tmpToDoData['manHour'],
                     tmpToDoData['genreId'], tmpToDoData['deadline'],
-                    tmpToDoData['contents'], tmpToDoData['place'], tmpToDoData['today']);
+                    tmpToDoData['contents'], tmpToDoData['place'], tmpToDoData['today'], tmpToDoData['id']);
                 this.toDoDataArray.push(data);
             }
 

--- a/src/ts/urimPlaneManager.ts
+++ b/src/ts/urimPlaneManager.ts
@@ -281,7 +281,9 @@ export class UrimPlaneManager {
 
         // toDoDataの色設定
         // ジャンルIDに応じた背景色に設定する
-        ctx.fillStyle = this.sdm.settingsData.getGenreData()[toDoTip.toDoData.getGenreId()]['color'];
+        ctx.fillStyle = this.sdm.settingsData.getGenreData().find(gd => {
+            return gd['id'] === toDoTip.toDoData.getGenreId();
+        })['color'];
         ctx.fill();
 
 


### PR DESCRIPTION
- `toDoDataManager.ts` と `settingsDataManager.ts` にIDを生成するコンストラクタとelectron-storeに格納済のIDを読み込むコンストラクタの２種類を作成
- genreIDの型がnumberとなっている部分をstringに修正
- `genreData.json` （テストデータ）のgenreIDを10桁IDに修正
- `toDoData.json` （テストデータ）にIDを追加 