### PR TITLE
[add]disable highlight

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,3 +1,7 @@
+*{
+    user-select: none;
+}
+
 #urim-plain-container{
     position: relative;
     height: 0;


### PR DESCRIPTION
todoダブルクリック時にHTML内のテキストがハイライト選択されてしまわないよう、HTMLの全タグに対して、選択不可能に設定しました。