### PR TITLE
[add]change color of todo when click

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -21,12 +21,13 @@
         <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect" id="create-btn">
             TODO作成
         </button>
-        <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect" id="delete-btn">
+        <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect" disabled="" id="delete-btn">
             削除
         </button>
-        <i class="far fa-star" style="visibility:hidden;"></i>
         <input type="image" src="../img/settings.svg" alt="設定画面を開く" class="mdl-button mdl-js-button" id="setting-btn">
-
+        <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect" style="visibility:hidden;" id="cancel-btn">
+            キャンセル
+        </button>
     </div>
 
     <!-- All of the Node.js APIs are available in this renderer process. -->
@@ -91,16 +92,13 @@
         </div>
         <div class="mdl-grid">
             <div class="mdl-layout-spacer">
-                <button type="button"
-                    class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">編集</button>
+                <button type="button" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">編集</button>
             </div>
             <div class="mdl-layout-spacer">
-                <button type="button"
-                    class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">達成</button>
+                <button type="button" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">達成</button>
             </div>
             <div class="mdl-layout-spacer">
-                <button type="button"
-                    class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">削除</button>
+                <button type="button" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">削除</button>
             </div>
         </div>
 

--- a/src/ts/ToDoTip.ts
+++ b/src/ts/ToDoTip.ts
@@ -31,6 +31,7 @@ class ToDoTip {
     public urgencyNumber: number;
     public importanceNumber: number;
     public fontScale: number;
+    public isDeleteCandidate: boolean;
 
     /**
      * todoデータをコピーする
@@ -39,6 +40,7 @@ class ToDoTip {
      */
     constructor(toDoData: ToDoData) {
         this.toDoData = toDoData;
+        this.isDeleteCandidate = false;
     }
 
     /**
@@ -79,28 +81,60 @@ class ToDoTip {
      */
     public toggleToday(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D, settingsData: settingsData) {
         this.toDoData.setToday(!this.toDoData.getIsToday());
+        this.render(canvas, ctx, settingsData);
+    }
+
+    public toggleBackgroundColor(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D, settingsData: settingsData) {
+        this.isDeleteCandidate = !this.isDeleteCandidate;
+        this.render(canvas, ctx, settingsData);
+    }
+
+    public render(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D, settingsData: settingsData) {
+        // toDoDataの矩形描画開始
         ctx.beginPath();
 
         // toDoDataの描画矩形の設定
-        // ジャンルIDに応じた背景色に設定する
         ctx.rect(this.left, this.top, this.width, this.height);
-        ctx.fillStyle = settingsData.getGenreData().find(gd => gd.getId() === this.toDoData.getGenreId()).getColor();
+
+        // toDoDataの色設定
+        // ジャンルIDに応じた背景色に設定する
+        ctx.fillStyle = this.isDeleteCandidate ? '#f00' : settingsData.getGenreData().find(gd => gd.getId() === this.toDoData.getGenreId()).getColor();
         ctx.fill();
+
 
         // toDoDataの文字描画開始
         ctx.beginPath();
         let fontSize = canvas.height * this.fontScale / this.importanceNumber;
 
+        // today用の星描画
         let todayIcon = '\uf005';
 
         ctx.font = this.toDoData.getIsToday() ? `900 ${fontSize}px 'Font Awesome 5 Free'` : `400 ${fontSize}px 'Font Awesome 5 Free'`;
 
         ctx.fillStyle = 'rgb(0, 0, 0)';
 
+        ctx.textBaseline = 'top';
         ctx.fillText(todayIcon, this.getTextPosition().x, this.getTextPosition().y);
 
         ctx.font = `900 ${fontSize}px 'Font Awesome 5 Free'`;
+
+        let title = this.toDoData.getTitle();
+        this.shortTitle = title;
+
+        if (ctx.measureText(todayIcon).width * 1.25 + ctx.measureText(title).width >= this.width) {
+            console.log('超えた', this.shortTitle);
+            while (true) {
+                if (ctx.measureText(todayIcon).width * 1.25 + ctx.measureText(`${title}..`).width < this.width) {
+                    this.shortTitle = title + '..';
+                    break;
+                }
+                title = title.slice(0, -1);
+            }
+        }
+
+        ctx.textBaseline = 'top';
         ctx.fillText(this.shortTitle, this.getTextPosition().x + ctx.measureText(todayIcon).width * 1.25, this.getTextPosition().y);
+
     }
 }
 

--- a/src/ts/renderer.ts
+++ b/src/ts/renderer.ts
@@ -1,6 +1,4 @@
 import { UrimCell, UrimPlaneManager } from './urimPlaneManager';
-import ToDoTip from './ToDoTip';
-import toDoData from './toDoData';
 import ToDoDataManager from './toDoDataManager';
 import Common from './common';
 import settingsDataManager from './settingsDataManager';
@@ -15,177 +13,214 @@ const tddm = new ToDoDataManager();
 
 const sdm = new settingsDataManager();
 
-const upm = new UrimPlaneManager();
+let upm: UrimPlaneManager;
 
 const common = new Common();
 
-let toDoTips: ToDoTip[];
 let ctx: CanvasRenderingContext2D;
 
-const render = (toDoDatas: toDoData[]) => {
-    ctx = upm.setupCanvas(canvas, toDoDatas);
-    toDoTips = upm.createToDoTips(canvas, toDoDatas);
-    upm.render(canvas, ctx, toDoTips);
+/**
+* html読み込み完了後、electron-storeからデータを読み込む
+* データ読み込み後に、描画処理
+*/
+window.onload = () => {
+    tddm.import();
+    sdm.import();
+    upm = new UrimPlaneManager(tddm.toDoDataArray);
+    addEventListners();
+    render();
+};
+
+const render = () => {
+    ctx = upm.setupCanvas(canvas);
+    upm.createToDoTips(canvas);
+    upm.render(canvas, ctx);
 }
 
-/**
- * toDoを右クリック時に、todayの星の色がトグルする
- */
-canvas.addEventListener('contextmenu', e => {
-    e.preventDefault();
+const addEventListners = () => {
+    /**
+     * toDoを右クリック時に、todayの星の色がトグルする
+     */
+    canvas.addEventListener('contextmenu', e => {
+        e.preventDefault();
 
-    const dpr = window.devicePixelRatio || 1;
-    const canvasRect = canvas.getBoundingClientRect();
+        const dpr = window.devicePixelRatio || 1;
+        const canvasRect = canvas.getBoundingClientRect();
 
-    const point = {
-        x: e.clientX * dpr - canvasRect.left * dpr,
-        y: e.clientY * dpr - canvasRect.top * dpr
-    };
+        const point = {
+            x: e.clientX * dpr - canvasRect.left * dpr,
+            y: e.clientY * dpr - canvasRect.top * dpr
+        };
 
-    // クリック判定処理
-    toDoTips.forEach(toDoTip => {
-        // TODO: upmにページ判定関数として定義する
-        if (toDoTip.page == upm.urimCell[common.imToNum[<keyof { [s: string]: number }>toDoTip.toDoData.getImportance()]][upm.urToCoord(toDoTip.toDoData.getUrgency())].pm.page) {
+        // クリック判定処理
+        upm.toDoTips.forEach(toDoTip => {
+            // TODO: upmにページ判定関数として定義する
+            if (toDoTip.page == upm.urimCell[common.imToNum[<keyof { [s: string]: number }>toDoTip.toDoData.getImportance()]][upm.urToCoord(toDoTip.toDoData.getUrgency())].pm.page) {
+                if (toDoTip.isOn(point)) {
+                    toDoTip.toggleToday(canvas, ctx, sdm.settingsData);
+                }
+            }
+        });
+
+    });
+
+    /**
+     * todoをダブルクリックすると、詳細画面に遷移する
+     */
+    canvas.addEventListener('dblclick', e => {
+        e.preventDefault();
+
+        const dpr = window.devicePixelRatio || 1;
+        const canvasRect = canvas.getBoundingClientRect();
+
+        const point = {
+            x: e.clientX * dpr - canvasRect.left * dpr,
+            y: e.clientY * dpr - canvasRect.top * dpr
+        };
+
+        // クリック判定処理
+        upm.toDoTips.forEach(toDoTip => {
             if (toDoTip.isOn(point)) {
-                toDoTip.toggleToday(canvas, ctx, sdm.settingsData);
+                ddlgm.renderContents(toDoTip.toDoData);
             }
-        }
+        });
+
     });
 
-});
+    /**
+     * todoや◀/▶のクリック判定処理
+     */
+    canvas.addEventListener('click', e => {
+        e.preventDefault();
 
-/**
- * todoをダブルクリックすると、詳細画面に遷移する
- */
-canvas.addEventListener('dblclick', e => {
-    e.preventDefault();
+        const dpr = window.devicePixelRatio || 1;
+        const canvasRect = canvas.getBoundingClientRect();
 
-    const dpr = window.devicePixelRatio || 1;
-    const canvasRect = canvas.getBoundingClientRect();
+        const point = {
+            x: e.clientX * dpr - canvasRect.left * dpr,
+            y: e.clientY * dpr - canvasRect.top * dpr
+        };
 
-    const point = {
-        x: e.clientX * dpr - canvasRect.left * dpr,
-        y: e.clientY * dpr - canvasRect.top * dpr
-    };
-
-    // クリック判定処理
-    toDoTips.forEach(toDoTip => {
-        if (toDoTip.isOn(point)) {
-            ddlgm.renderContents(toDoTip.toDoData);
-        }
-    });
-
-});
-
-/**
- * ◀/▶をクリックすると、同一セル内の前/次ページのtodoを表示する
- */
-canvas.addEventListener('click', e => {
-    e.preventDefault();
-
-    const dpr = window.devicePixelRatio || 1;
-    const canvasRect = canvas.getBoundingClientRect();
-
-    const point = {
-        x: e.clientX * dpr - canvasRect.left * dpr,
-        y: e.clientY * dpr - canvasRect.top * dpr
-    };
-
-    // クリック判定処理
-    // upm.pgcを全探索して、hasPageのやつだけ、クリック判定する
-    upm.urimCell.forEach((imArray: UrimCell[]) => {
-        imArray.forEach((cell: UrimCell) => {
-            if (cell.pm.hasPages) {
-                if (cell.pm.isPrevClicked(point)) {
-                    cell.pm.page -= 1;
-                    if (cell.pm.page < cell.pm.minPage) {
-                        cell.pm.page = cell.pm.maxPage;
+        // ◀/▶のクリック判定処理
+        // upm.pgcを全探索して、hasPageのやつだけ、クリック判定する
+        // クリックすると、同一セル内の前/次ページのtodoを表示する
+        upm.urimCell.forEach((imArray: UrimCell[]) => {
+            imArray.forEach((cell: UrimCell) => {
+                if (cell.pm.hasPages) {
+                    if (cell.pm.isPrevClicked(point)) {
+                        cell.pm.page -= 1;
+                        if (cell.pm.page < cell.pm.minPage) {
+                            cell.pm.page = cell.pm.maxPage;
+                        }
+                        upm.render(canvas, ctx);
                     }
-                    upm.render(canvas, ctx, toDoTips);
-                }
-                else if (cell.pm.isNextClicked(point)) {
-                    cell.pm.page += 1;
-                    if (cell.pm.page > cell.pm.maxPage) {
-                        cell.pm.page = cell.pm.minPage;
+                    else if (cell.pm.isNextClicked(point)) {
+                        cell.pm.page += 1;
+                        if (cell.pm.page > cell.pm.maxPage) {
+                            cell.pm.page = cell.pm.minPage;
+                        }
+                        upm.render(canvas, ctx);
                     }
-                    upm.render(canvas, ctx, toDoTips);
                 }
-            }
+            })
         })
-    })
-});
 
-/**
- * todoか◀/▶上にマウスがある間、マウスアイコンを指にする
- */
-canvas.addEventListener('mousemove', e => {
-    e.preventDefault();
-
-    const dpr = window.devicePixelRatio || 1;
-    const canvasRect = canvas.getBoundingClientRect();
-
-    const point = {
-        x: e.clientX * dpr - canvasRect.left * dpr,
-        y: e.clientY * dpr - canvasRect.top * dpr
-    };
-
-    let isOnToDoOrPm = false;
-
-    // クリック判定処理
-    toDoTips.forEach(toDoTip => {
-        if (toDoTip.isOn(point)) {
-            canvas.style.cursor = 'pointer';
-            isOnToDoOrPm = true;
-        }
-    });
-
-    upm.urimCell.forEach((imArray: UrimCell[]) => {
-        imArray.forEach((cell: UrimCell) => {
-            if (cell.pm.hasPages && cell.pm.isOn(point)) {
-                canvas.style.cursor = 'pointer';
-                isOnToDoOrPm = true;
+        // todoのクリック判定処理
+        // クリックすると、削除機能が有効化される
+        upm.toDoTips.forEach(toDoTip => {
+            if (toDoTip.isOn(point)) {
+                // 削除ボタンを有効化する
+                document.getElementById('delete-btn').removeAttribute('disabled');
+                // キャンセルボタンの追加
+                document.getElementById('cancel-btn').style.visibility = 'visible';
+                // 背景色を変更する
+                toDoTip.toggleBackgroundColor(canvas, ctx, sdm.settingsData);
+                // 削除リストに追加する
             }
         });
     });
 
-    if (!isOnToDoOrPm) {
-        canvas.style.cursor = 'default';
-    }
-})
+    /**
+     * todoか◀/▶上にマウスがある間、マウスアイコンを指にする
+     */
+    canvas.addEventListener('mousemove', e => {
+        e.preventDefault();
 
-/**
- * html読み込み完了後、electron-storeからデータを読み込む
- * データ読み込み後に、描画処理
- */
-window.onload = () => {
-    tddm.import();
-    sdm.import();
-    render(tddm.toDoDataArray);
+        const dpr = window.devicePixelRatio || 1;
+        const canvasRect = canvas.getBoundingClientRect();
+
+        const point = {
+            x: e.clientX * dpr - canvasRect.left * dpr,
+            y: e.clientY * dpr - canvasRect.top * dpr
+        };
+
+        let isOnToDoOrPm = false;
+
+        // クリック判定処理
+        upm.toDoTips.forEach(toDoTip => {
+            if (toDoTip.isOn(point)) {
+                canvas.style.cursor = 'pointer';
+                isOnToDoOrPm = true;
+            }
+        });
+
+        upm.urimCell.forEach((imArray: UrimCell[]) => {
+            imArray.forEach((cell: UrimCell) => {
+                if (cell.pm.hasPages && cell.pm.isOn(point)) {
+                    canvas.style.cursor = 'pointer';
+                    isOnToDoOrPm = true;
+                }
+            });
+        });
+
+        if (!isOnToDoOrPm) {
+            canvas.style.cursor = 'default';
+        }
+    })
+
+    /**
+     * ウィンドウをリサイズする度に、描画し直す
+     */
+    window.addEventListener('resize', () => { render() }, false);
+
+    /**
+     * 概要モードボタンをクリックすると、概要モード画面へ遷移する
+     */
+    document.getElementById('abst-btn').addEventListener('click', () => {
+        tddm.export();
+        sdm.export();
+        location.href = '../html/abst.html';
+    }, false);
+
+    /**
+     * 作成ボタンをクリックすると、todo作成画面へ遷移する
+     */
+    document.getElementById('create-btn').addEventListener('click', () => {
+        tddm.export();
+        sdm.export();
+        location.href = '../html/form.html';
+    }, false);
+
+    /**
+    * 削除ボタンを押下時に、削除候補を削除、削除ボタンを無効化、キャンセルボタンの消去、レンダリングし直しをする
+    */
+    document.getElementById('delete-btn').addEventListener('click', () => {
+        document.getElementById('delete-btn').setAttribute('disabled', '');
+        document.getElementById('cancel-btn').style.visibility = 'hidden';
+        upm.deleteToDoTips(tddm);
+        render();
+    });
+
+    /**
+     * キャンセルボタンを押下時に、削除ボタンを無効化、todoの色をもとに戻す、削除候補のリセット、キャンセルボタンの消去をする
+     */
+    document.getElementById('cancel-btn').addEventListener('click', () => {
+        document.getElementById('delete-btn').setAttribute('disabled', '');
+        document.getElementById('cancel-btn').style.visibility = 'hidden';
+        upm.toDoTips.forEach(toDoTip => {
+            if (toDoTip.isDeleteCandidate) {
+                toDoTip.toggleBackgroundColor(canvas, ctx, sdm.settingsData);
+            }
+        })
+    });
 };
-
-/**
- * ウィンドウをリサイズする度に、描画し直す
- */
-window.addEventListener('resize', () => { render(tddm.toDoDataArray) }, false);
-
-const abstBtn = document.getElementById('abst-btn');
-
-/**
- * 概要モードボタンをクリックすると、概要モード画面へ遷移する
- */
-abstBtn.addEventListener('click', () => {
-    tddm.export();
-    sdm.export();
-    location.href = '../html/abst.html';
-}, false);
-
-const createBtn = document.getElementById('create-btn');
-
-/**
- * 作成ボタンをクリックすると、todo作成画面へ遷移する
- */
-createBtn.addEventListener('click', () => {
-    tddm.export();
-    sdm.export();
-    location.href = '../html/form.html';
-}, false);

--- a/src/ts/toDoDataManager.ts
+++ b/src/ts/toDoDataManager.ts
@@ -126,12 +126,12 @@ export default class toDoDataManager {
     public delete(id: string) {
         var isDeleted = false;
 
-        for (let index in this.toDoDataArray) {
-            if (this.toDoDataArray[index]['id'] == id) {
-                delete this.toDoDataArray[index];
+        this.toDoDataArray = this.toDoDataArray.filter(todoData => {
+            if (todoData.getId() === id) {
                 isDeleted = true;
             }
-        }
+            return todoData.getId() !== id;
+        });
 
         if (!isDeleted) {
             console.log(`Cannot find todo data(id: ${id})`);


### PR DESCRIPTION
- Urim画面にてtodoの削除機能を追加
    - todoを左クリックで削除候補に追加（todoの背景色が赤色に変化）
    - 削除候補にtodoを追加後、削除ボタン押下でtodoを削除
    - キャンセルボタン押下で、削除候補をリセット
- `toDoDataManager` のdelete関数を修正
    ある要素を削除後にexportすると、削除した要素以降の要素も削除されていたため、削除した要素をなくした配列へとフィルタリングし直すことにしました。electron-storeのset関数がundefined要素以降の要素は処理をスキップしていると思われます。